### PR TITLE
Prolog legare exec

### DIFF
--- a/prolog/legare-executie/README.md
+++ b/prolog/legare-executie/README.md
@@ -83,8 +83,8 @@ X = Y.
 ```
 
 În ultimul exemplu deși cele două expresii diferă, și ele referă variabile care
-nu sunt instanțiate la aceiași valoare, există cel puțin o **legare** ca să se
-satisfacă scopul, și anume dacă `X` și `Y` se leagă la aceiași valoare.
+nu sunt instanțiate la aceeași valoare, există cel puțin o **legare** ca să se
+satisfacă scopul, și anume dacă `X` și `Y` se leagă la aceeași valoare.
 
 ```prolog
 ?- X = Y, string_concat("P", "P", X), writeln(Y).
@@ -116,7 +116,7 @@ true.
 ```
 
 În exemplul anterior am văzut că variabile denumite la fel (având același
-indentificator), `A` se pot lega în aceiași interogare la diferite valori, `1`
+indentificator), `A` se pot lega în aceeași interogare la diferite valori, `1`
 și `2`. Deși cel mai bine este să consultați standardul limbajului, de obicei
 întinderea domeniului de vizibilitate a unei variabile este o singură caluză sau
 o interogare.
@@ -508,5 +508,6 @@ true.
 ```
 
 ## Resurse
+-   [Cheatsheet](https://github.com/cs-pub-ro/PP-laboratoare/raw/master/prolog/intro/prolog-cheatsheet-1.pdf)
 -   [Schelet](https://ocw.cs.pub.ro/courses/_media/pp/22/laboratoare/prolog/legare-executie-schelet.zip)
 -   [Soluții](https://ocw.cs.pub.ro/courses/_media/pp/22/laboratoare/prolog/legare-executie-solutii.zip)

--- a/prolog/legare-executie/README.md
+++ b/prolog/legare-executie/README.md
@@ -441,7 +441,7 @@ Fie problema identificării unei submulțimi de sumă dată. (en. *subset sum*) 
 rezolvăm cât mai simplu, mai întâi:
 
 ```prolog
-subset_sum(+List, ?Sum).
+% subset_sum(+List, ?Sum).
 subset_sum(_, 0).
 subset_sum([_ | Rest], Sum) :- subset_sum(Rest, Sum).
 subset_sum([Head | Rest], Sum) :- subset_sum(Rest, S1), Sum is S1 + Head.
@@ -460,7 +460,7 @@ s-ar putea dovedi nefolositoare în premisa de testare, `Sum is S1 + Head`.
 ## Backtracking atunci când cunoaștem dimensiunea soluției
 
 ```prolog
-subset_sum(+List, +Sum).
+% subset_sum(+List, +Sum).
 subset_sum(_, 0) :- !.
 subset_sum([Head | Rest], Sum) :- Head > Sum, !, subset_sum(Rest, Sum).
 subset_sum([Head | Rest], Sum) :-

--- a/prolog/legare-executie/README.md
+++ b/prolog/legare-executie/README.md
@@ -145,6 +145,14 @@ lazy(marius).
 
 p1(X) :- student(X), \+ lazy(X).
 p2(X) :- \+ lazy(X), student(X).
+
+% se incearcă și găsirea următorului student (de unde și spatiul dintre andrei și '.') ce îndeplinește
+% condiția, însă nu mai este găsit niciunul
+?- p1(X).
+X = andrei .
+
+?- p2(X).
+false.
 ```
 
 Acesta se întâmplă pentru că, Prolog **nu poate să derive, pe baza negației,
@@ -511,3 +519,4 @@ true.
 -   [Cheatsheet](https://github.com/cs-pub-ro/PP-laboratoare/raw/master/prolog/intro/prolog-cheatsheet-1.pdf)
 -   [Schelet](https://ocw.cs.pub.ro/courses/_media/pp/22/laboratoare/prolog/legare-executie-schelet.zip)
 -   [Soluții](https://ocw.cs.pub.ro/courses/_media/pp/22/laboratoare/prolog/legare-executie-solutii.zip)
+

--- a/prolog/legare-executie/README.md
+++ b/prolog/legare-executie/README.md
@@ -146,10 +146,10 @@ lazy(marius).
 p1(X) :- student(X), \+ lazy(X).
 p2(X) :- \+ lazy(X), student(X).
 
-% se incearcă și găsirea următorului student (de unde și spatiul dintre andrei și '.') ce îndeplinește
-% condiția, însă nu mai este găsit niciunul
 ?- p1(X).
-X = andrei .
+X = andrei ;
+false. % se incearcă și găsirea următorului student care satisface cea de-a doua
+% premisă, însă nu se poate
 
 ?- p2(X).
 false.
@@ -516,7 +516,7 @@ true.
 ```
 
 ## Resurse
--   [Cheatsheet](https://github.com/cs-pub-ro/PP-laboratoare/raw/master/prolog/intro/prolog-cheatsheet-1.pdf)
+-   [Cheatsheet](https://github.com/cs-pub-ro/PP-laboratoare/blob/prolog-legare-exec/prolog/legare-executie/prolog_cheatsheet_2.pdf)
 -   [Schelet](https://ocw.cs.pub.ro/courses/_media/pp/22/laboratoare/prolog/legare-executie-schelet.zip)
 -   [Soluții](https://ocw.cs.pub.ro/courses/_media/pp/22/laboratoare/prolog/legare-executie-solutii.zip)
 


### PR DESCRIPTION
Pentru al doilea laborator de Prolog, am făcut următoarele schimbări:

- introducerea unei secțiuni de recapitulare ca să se clarifice legarea și unificarea, termeni folosiți intens în restul labului
- eliminarea explicațiilor excesive ale operatorului `\+`, discutat și labul trecut
- detalierea procesului de generare de soluții
- modificări estetice (spațieri, redenumiri)

Totuși laboratorul este prea **lung**. @alex-constantin și @Maxxtra orice idei sunt binevenite.

@andreiolaru-ro încarci, te rog, scheletul și soluțiile actualizând data publicării? 